### PR TITLE
feat: optional serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ serde = { version = "1", default-features = false, optional = true }
 pyo3 = { version = "0.21.2", features = ["extension-module"], optional = true }
 numpy = { version = "0.21.0", optional = true }
 
+[dev-dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1" }
+
 [features]
 std = []
 pyo3 = ["std", "dep:pyo3", "dep:numpy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ categories = ["data-structures", "mathematics", "encoding"]
 bytemuck = "1"
 num-traits = "0.2"
 
+serde = { version = "1", default-features = false, optional = true }
 pyo3 = { version = "0.21.2", features = ["extension-module"], optional = true }
 numpy = { version = "0.21.0", optional = true }
 
 [features]
 std = []
 pyo3 = ["std", "dep:pyo3", "dep:numpy"]
+serde = ["dep:serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -709,6 +709,66 @@ impl_bits_fmt! {
     impl fmt::Binary
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for i24 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer {
+        serializer.serialize_i32(self.to_i32())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for i24 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de> {
+        deserializer.deserialize_i32(I24Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+struct I24Visitor;
+
+#[cfg(feature = "serde")]
+impl<'de> serde::de::Visitor<'de> for I24Visitor {
+    type Value = crate::i24;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        formatter.write_str("an integer between -2^23 and 2^23")
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error, {
+        Ok(v.into())
+    }
+
+    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error, {
+        Ok(v.into())
+    }
+
+    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error, {
+        Ok(v.into())
+    }
+
+    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error, {
+        Ok(v.into())
+    }
+
+    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error, {
+        v.try_into().map_err(|_| E::custom("i24 out of range!"))
+    }
+}
+
 impl Hash for i24 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         I24Repr::hash(&self.0, state)


### PR DESCRIPTION
Should work in no-std as well. The "i24 out of range" message could be improved by specifying the value, I suppose, but not sure how to do it without std (and bringing in a library just for this seemed overkill).

I intend to write tests for it as soon as I have time.