### PR TITLE
features for num-traits to fix no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["data-structures", "mathematics", "encoding"]
 
 [dependencies]
 bytemuck = "1"
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 
 serde = { version = "1", default-features = false, optional = true }
 pyo3 = { version = "0.24.2", features = ["extension-module"], optional = true }
@@ -23,6 +23,7 @@ serde_json = { version = "1" }
 
 [features]
 alloc = []
-std = []
+libm = ["num-traits/libm"]
+std = ["num-traits/std"]
 pyo3 = ["std", "dep:pyo3", "dep:numpy"]
 serde = ["dep:serde"]


### PR DESCRIPTION
I test this with cargo check and with my own code.

```
% cargo check --target thumbv7em-none-eabihf
   Compiling autocfg v1.4.0
    Checking bytemuck v1.23.1
   Compiling num-traits v0.2.19
    Checking i24 v2.1.0 (/Users/bryan/code/i24)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.18s
```
    
https://github.com/BlinkyStitt/musical-lights-rs/blob/main/musical-stm32/Cargo.toml#L103

It seems to be working.